### PR TITLE
fix empty queue in last read

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,11 +126,6 @@ module.exports = class DependencyStream extends Readable {
   }
 
   async _read (cb) {
-    if (this._queue.length === 0) {
-      this.push(null)
-      return cb(null)
-    }
-
     try {
       while (this._queue.length > 0) {
         const key = this._queue.shift()
@@ -144,6 +139,10 @@ module.exports = class DependencyStream extends Readable {
       return cb(err)
     }
 
+    if (this._queue.length === 0) {
+      this.push(null)
+      return cb(null)
+    }
     cb(null)
   }
 


### PR DESCRIPTION
Fix for corner case produced in the next situation:

```  
async _read (cb) {
   // this._queue.length is 1
    if (this._queue.length === 0) {
      this.push(null)
      return cb(null)
    }

    try {
      while (this._queue.length > 0) {
        const key = this._queue.shift()
        // this.module.has(key) is true
        if (this.modules.has(key)) continue
        const data = await this._addOnce(key)
        this.modules.set(key, data)
        this._pending.delete(key)
        if (this.push(data) === false) break
      }
    } catch (err) {
      return cb(err)
    }

    cb(null)
  }
```

During the stream read:

```
    const dependencyStream = new DependencyStream(drive, { entrypoint })
    for await (const dep of dependencyStream) {
    // doesnt do the last read (when queue.length is 0
    }
  }
```

IMPORTANT: I have been able to repro this issue only in Bare, the same test works for Node, 